### PR TITLE
Refactor monitoring dashboard for service-centric flow

### DIFF
--- a/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringDashboardDto.cs
+++ b/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringDashboardDto.cs
@@ -6,5 +6,5 @@ public class MonitoringDashboardDto
 {
     public MonitoringSummaryDto Summary { get; set; } = new();
 
-    public List<JobStatusDto> Jobs { get; set; } = new();
+    public List<MonitoringServiceDto> Services { get; set; } = new();
 }

--- a/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringServiceDto.cs
+++ b/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringServiceDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace HRSDataIntegration.Monitoring;
+
+public class MonitoringServiceDto
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public DateTime? LastCheckTime { get; set; }
+}

--- a/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringSummaryDto.cs
+++ b/src/HRSDataIntegration.Application.Contracts/Monitoring/MonitoringSummaryDto.cs
@@ -1,39 +1,12 @@
 using System;
 
-
 namespace HRSDataIntegration.Monitoring;
 
 public class MonitoringSummaryDto
 {
-    public int TotalJobs { get; set; }
+    public int TotalServices { get; set; }
 
-    public int ActiveJobs { get; set; }
-
-    public int TotalJobDetails { get; set; }
-
-    public int TotalJobGroups { get; set; }
-
-    public int TotalJobRasteh { get; set; }
+    public int ActiveServices { get; set; }
 
     public DateTime GeneratedAt { get; set; }
-
-
-namespace HRSDataIntegration.Monitoring
-{
-    public class MonitoringSummaryDto
-    {
-        public int TotalJobs { get; set; }
-        public int ActiveJobs { get; set; }
-        public int TotalJobDetails { get; set; }
-
-        // from codex/add-monitoringapplication-to-datasync-gi4p0i
-        public int TotalJobGroups { get; set; }
-        public int TotalJobRasteh { get; set; }
-
-        // from main
-        public int TotalUnits { get; set; }
-        public int TotalPosts { get; set; }
-
-        public DateTime GeneratedAt { get; set; }
-    }
 }

--- a/src/HRSDataIntegration.Application/Monitoring/MonitoringAppService.cs
+++ b/src/HRSDataIntegration.Application/Monitoring/MonitoringAppService.cs
@@ -1,186 +1,21 @@
-using System;
-using System.Globalization;
-using System.Linq;
 using System.Threading.Tasks;
-using HRSDataIntegration;
-using HRSDataIntegration.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace HRSDataIntegration.Monitoring;
 
 public class MonitoringAppService : HRSDataIntegrationAppService, IMonitoringAppService
 {
-    private readonly ISqlRepository<Job> _jobRepository;
-    private readonly ISqlRepository<JobDetail> _jobDetailRepository;
-    private readonly ISqlRepository<JobGroup> _jobGroupRepository;
-    private readonly ISqlRepository<JobRasteh> _jobRastehRepository;
-
-    private readonly ISqlRepository<JobGroup> _jobGroupRepository;
-    private readonly ISqlRepository<JobRasteh> _jobRastehRepository;
-
-    private readonly ISqlRepository<JobGroup> _jobGroupRepository;
-    private readonly ISqlRepository<JobRasteh> _jobRastehRepository;
-
-    //  main
-    private readonly ISqlRepository<Unit> _unitRepository;
-    private readonly ISqlRepository<Post> _postRepository;
-
-//main
-    public MonitoringAppService(
-        ISqlRepository<Job> jobRepository,
-        ISqlRepository<JobDetail> jobDetailRepository,
-        ISqlRepository<JobGroup> jobGroupRepository,
-        ISqlRepository<JobRasteh> jobRastehRepository)
-
-        ISqlRepository<JobRasteh> jobRastehRepository)
-
-        ISqlRepository<JobRasteh> jobRastehRepository,
-        ISqlRepository<Unit> unitRepository,
-        ISqlRepository<Post> postRepository)
-
+    public Task<MonitoringDashboardDto> GetDashboardAsync()
     {
-        _jobRepository = jobRepository;
-        _jobDetailRepository = jobDetailRepository;
-        _jobGroupRepository = jobGroupRepository;
-        _jobRastehRepository = jobRastehRepository;
-       _unitRepository = unitRepository;
-        _postRepository = postRepository;
-
-    }
-
-    public async Task<MonitoringDashboardDto> GetDashboardAsync()
-    {
-=======
-        var jobQueryable = _jobRepository
-            .GetQueryable()
-            .AsNoTracking();
-
-        var jobDetailQueryable = _jobDetailRepository
-            .GetQueryable()
-            .AsNoTracking();
-
-        var jobGroupQueryable = _jobGroupRepository
-            .GetQueryable()
-            .AsNoTracking();
-
-        var jobRastehQueryable = _jobRastehRepository
-            .GetQueryable()
-            .AsNoTracking();
-
-=======
-=======
-        // Queryables (با AsNoTracking برای کارایی بهتر dashboard)
-        var jobQueryable = _jobRepository.GetQueryable().AsNoTracking();
-        var jobDetailQueryable = _jobDetailRepository.GetQueryable().AsNoTracking();
-        var jobGroupQueryable = _jobGroupRepository.GetQueryable().AsNoTracking();
-        var jobRastehQueryable = _jobRastehRepository.GetQueryable().AsNoTracking();
-        var unitQueryable = _unitRepository.GetQueryable().AsNoTracking();
-        var postQueryable = _postRepository.GetQueryable().AsNoTracking();
-
- 
-        var summary = new MonitoringSummaryDto
+        var dashboard = new MonitoringDashboardDto
         {
-            TotalJobs = await AsyncExecuter.CountAsync(jobQueryable),
-            ActiveJobs = await AsyncExecuter.CountAsync(jobQueryable.Where(job => job.IsActive)),
-            TotalJobDetails = await AsyncExecuter.CountAsync(jobDetailQueryable),
-=======
-// codex/add-monitoringapplication-to-datasync-siqgy5
-            TotalJobGroups = await AsyncExecuter.CountAsync(jobGroupQueryable),
-            TotalJobRasteh = await AsyncExecuter.CountAsync(jobRastehQueryable)
-        };
-
-        var jobs = await AsyncExecuter.ToListAsync(
-            jobDetailQueryable
-                .OrderByDescending(detail => detail.LastActivityTime)
-                .Take(100)
-                .Select(detail => new JobStatusDto
-                {
-                    Id = detail.Id,
-                    Code = detail.Code,
-                    Title = detail.Title,
-                    JobGroupTitle = detail.JobGroup != null ? detail.JobGroup.Title : null,
-                    JobRastehTitle = detail.JobRasteh != null ? detail.JobRasteh.Title : null,
-                    JobIsActive = detail.Job != null && detail.Job.IsActive,
-                    EffectiveFrom = ConvertOracleDate(detail.EffectiveDateFrom),
-                    EffectiveTo = ConvertOracleDate(detail.EffectiveDateTo),
-                    LastActivityTime = detail.LastActivityTime,
-                    StateTitle = detail.StateTitle,
-                    LastActionTitle = detail.LastActionTitle
-                })
-        );
-
-=======
-
-
-            // from codex/add-monitoringapplication-to-datasync-gi4p0i
-            TotalJobGroups = await AsyncExecuter.CountAsync(jobGroupQueryable),
-            TotalJobRasteh = await AsyncExecuter.CountAsync(jobRastehQueryable),
-
-            // from main
-            TotalUnits = await AsyncExecuter.CountAsync(unitQueryable),
-            TotalPosts = await AsyncExecuter.CountAsync(postQueryable)
-        };
-
-        // جزئیات آخرین 100 رکورد با include برای دسترسی به navigation ها
-        var jobDetails = await AsyncExecuter.ToListAsync(
-            jobDetailQueryable
-                .Include(detail => detail.Job)
-                .Include(detail => detail.JobGroup)
-                .Include(detail => detail.JobRasteh)
-                .OrderByDescending(detail => detail.LastActivityTime)
-                .Take(100)
-        );
-
-        var jobs = jobDetails
-            .Select(detail => new JobStatusDto
+            Summary = new MonitoringSummaryDto
             {
-                Id = detail.Id,
-                Code = detail.Code,
-                Title = detail.Title,
-                JobGroupTitle = detail.JobGroup?.Title,
-                JobRastehTitle = detail.JobRasteh?.Title,
-                JobIsActive = detail.Job?.IsActive ?? false,
-                EffectiveFrom = ConvertOracleDate(detail.EffectiveDateFrom),
-                EffectiveTo = ConvertOracleDate(detail.EffectiveDateTo),
-                LastActivityTime = detail.LastActivityTime,
-                StateTitle = detail.StateTitle,
-                LastActionTitle = detail.LastActionTitle
-            })
-            .ToList();
-
-
-        foreach (var job in jobs)
-        {
-            job.LastActivityTime = Clock.Normalize(job.LastActivityTime);
-        }
-
-        var latestActivity = jobs.FirstOrDefault()?.LastActivityTime;
-        summary.GeneratedAt = latestActivity.HasValue && latestActivity.Value != default
-            ? Clock.Normalize(latestActivity.Value)
-            : default;
-
-            : Clock.Normalize(Clock.Now);
-
-        return new MonitoringDashboardDto
-        {
-            Summary = summary,
-            Jobs = jobs
+                TotalServices = 0,
+                ActiveServices = 0,
+                GeneratedAt = default
+            }
         };
-    }
 
-    private static DateTime? ConvertOracleDate(int value)
-    {
-        if (value <= 0)
-        {
-            return null;
-        }
-
-        var formatted = value.ToString("00000000", CultureInfo.InvariantCulture);
-        if (DateTime.TryParseExact(formatted, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
-        {
-            return date;
-        }
-
-        return null;
+        return Task.FromResult(dashboard);
     }
 }

--- a/src/HRSDataIntegration.Domain.Shared/Localization/HRSDataIntegration/en.json
+++ b/src/HRSDataIntegration.Domain.Shared/Localization/HRSDataIntegration/en.json
@@ -4,61 +4,18 @@
     "AppName": "HRSDataIntegration",
     "Menu:Home": "Home",
     "Menu:Monitoring": "Monitoring",
-    "Monitoring:Title": "Monitoring dashboard",
-    "Monitoring:TotalJobs": "Jobs",
-    "Monitoring:ActiveJobs": "{0} active records",
-    "Monitoring:JobDetails": "Job details",
+    "Monitoring:Title": "Service monitoring",
+    "Monitoring:SummaryTotalServices": "Registered services",
+    "Monitoring:SummaryActiveServices": "{0} active services",
     "Monitoring:LastUpdated": "Updated {0}",
-
-    "Monitoring:JobGroups": "Job groups",
-    "Monitoring:JobGroupsDescription": "Distinct groups registered for positions",
-    "Monitoring:JobRasteh": "Job rasteh",
-    "Monitoring:JobRastehDescription": "Rasteh classifications available in the system",
-
-
-    "Monitoring:Units": "Units",
-    "Monitoring:UnitsDescription": "Organizational structure records",
-    "Monitoring:Posts": "Posts",
-    "Monitoring:PostsDescription": "Organizational post definitions",
-
-
-    "Monitoring:JobStatus": "Latest job activities",
-    "Monitoring:JobStatusDescription": "Tracking the most recent changes received from source systems.",
-    "Monitoring:SearchJobs": "Filter jobs...",
-    "Monitoring:JobCode": "Code",
-    "Monitoring:JobTitle": "Title",
-
-    "Monitoring:JobGroupColumn": "Group",
-    "Monitoring:JobRastehColumn": "Rasteh",
-=======
-
-    "Monitoring:JobGroupColumn": "Group",
-    "Monitoring:JobRastehColumn": "Rasteh",
-
-    "Monitoring:JobGroupColumn": "Group",
-    "Monitoring:JobRastehColumn": "Rasteh",
-
-    "Monitoring:JobGroup": "Group",
-    "Monitoring:JobRasteh": "Rasteh",
-
-
-    "Monitoring:IsActive": "Active",
-    "Monitoring:EffectiveFrom": "Effective from",
-    "Monitoring:EffectiveTo": "Effective to",
-    "Monitoring:LastActivity": "Last activity",
-    "Monitoring:State": "State",
-    "Monitoring:LastAction": "Last action",
-    "Monitoring:NoJobs": "No job activities have been received yet.",
-    "Monitoring:Active": "Active",
-    "Monitoring:Inactive": "Inactive",
     "Monitoring:NeverUpdated": "No activity recorded yet.",
-
-
-    "Monitoring:NeverUpdated": "No activity recorded yet.",
-
-    "Monitoring:NeverUpdated": "No activity recorded yet.",
-
-
+    "Monitoring:NoServicesTitle": "No services registered",
+    "Monitoring:NoServicesDescription": "Start by defining the integrations you want to observe.",
+    "Monitoring:CreateService": "Create service",
+    "Monitoring:ServiceActive": "Active",
+    "Monitoring:ServiceInactive": "Inactive",
+    "Monitoring:ServiceLastCheck": "Last check {0}",
+    "Monitoring:ServiceNeverChecked": "Not checked yet",
     "LongWelcomeMessage": "Welcome to the application. This is a startup project based on the ABP framework. For more information visit",
     "Welcome": "Welcome"
   }

--- a/src/HRSDataIntegration.Web/Pages/Monitoring/Index.cshtml
+++ b/src/HRSDataIntegration.Web/Pages/Monitoring/Index.cshtml
@@ -10,18 +10,9 @@
 @{
     ViewBag.PageTitle = L["Monitoring:Title"];
     PageLayout.Content.MenuItemName = HRSDataIntegrationMenus.Monitoring;
-    var lastUpdatedText = Model.MonitoringSummary.GeneratedAt != default
-        ? L["Monitoring:LastUpdated", Model.MonitoringSummary.GeneratedAt.ToLocalTime().ToString("g")]
-        : L["Monitoring:NeverUpdated"];
-
-    var lastUpdatedText = Model.MonitoringSummary.GeneratedAt != default
-        ? L["Monitoring:LastUpdated", Model.MonitoringSummary.GeneratedAt.ToLocalTime().ToString("g")]
-        : L["Monitoring:NeverUpdated"];
-
     var lastUpdatedText = Model.Summary.GeneratedAt != default
         ? L["Monitoring:LastUpdated", Model.Summary.GeneratedAt.ToLocalTime().ToString("g")]
         : L["Monitoring:NeverUpdated"];
-
 }
 
 @section styles {
@@ -29,205 +20,66 @@
 }
 
 <div class="monitoring-dashboard container-fluid px-0">
-    <div class="row g-3">
-        <div class="col-12 col-md-6 col-xxl">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:TotalJobs"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobs</div>
-                    <div class="text-muted">@L["Monitoring:ActiveJobs", Model.MonitoringSummary.ActiveJobs]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobs</div>
-                    <div class="text-muted">@L["Monitoring:ActiveJobs", Model.MonitoringSummary.ActiveJobs]</div>
-
-                    <div class="display-6 fw-bold">@Model.Summary.TotalJobs</div>
-                    <div class="text-muted">@L["Monitoring:ActiveJobs", Model.Summary.ActiveJobs]</div>
-
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6 col-xxl">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobDetails"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobDetails</div>
-                    <div class="text-muted">@lastUpdatedText</div>
-
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobDetails</div>
-                    <div class="text-muted">@lastUpdatedText</div>
-
-                    <div class="display-6 fw-bold">@Model.Summary.TotalJobDetails</div>
-                    <div class="text-muted">@lastUpdatedText</div>
-
-                    <div class="text-muted">@L["Monitoring:LastUpdated", Model.Summary.GeneratedAt.ToLocalTime().ToString("g")]</div>
-
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6 col-xxl">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobGroups"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobGroups</div>
-                    <div class="text-muted">@L["Monitoring:JobGroupsDescription"]</div>
-
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobGroups"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobGroups</div>
-                    <div class="text-muted">@L["Monitoring:JobGroupsDescription"]</div>
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobGroups"]</div>
-                    <div class="display-6 fw-bold">@Model.Summary.TotalJobGroups</div>
-                    <div class="text-muted">@L["Monitoring:JobGroupsDescription"]</div>
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:Units"]</div>
-                    <div class="display-6 fw-bold">@Model.Summary.TotalUnits</div>
-                    <div class="text-muted">@L["Monitoring:UnitsDescription"]</div>
-
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6 col-xxl">
-            <div class="card shadow-sm h-100">
-                <div class="card-body">
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobRasteh"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobRasteh</div>
-                    <div class="text-muted">@L["Monitoring:JobRastehDescription"]</div>
-=======
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobRasteh"]</div>
-                    <div class="display-6 fw-bold">@Model.MonitoringSummary.TotalJobRasteh</div>
-                    <div class="text-muted">@L["Monitoring:JobRastehDescription"]</div>
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:JobRasteh"]</div>
-                    <div class="display-6 fw-bold">@Model.Summary.TotalJobRasteh</div>
-                    <div class="text-muted">@L["Monitoring:JobRastehDescription"]</div>
-
-                    <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:Posts"]</div>
-                    <div class="display-6 fw-bold">@Model.Summary.TotalPosts</div>
-                    <div class="text-muted">@L["Monitoring:PostsDescription"]</div>
-
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="card shadow-sm mt-4">
-        <div class="card-header d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+    <div class="card shadow-sm mb-4">
+        <div class="card-body d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
             <div>
-                <h5 class="mb-0">@L["Monitoring:JobStatus"]</h5>
-                <div class="text-muted small">@L["Monitoring:JobStatusDescription"]</div>
+                <div class="text-muted text-uppercase fw-semibold small">@L["Monitoring:SummaryTotalServices"]</div>
+                <div class="display-6 fw-bold">@Model.Summary.TotalServices</div>
+                <div class="text-muted">@L["Monitoring:SummaryActiveServices", Model.Summary.ActiveServices]</div>
             </div>
-            <div class="ms-md-auto">
-                <input type="search" class="form-control" placeholder="@L["Monitoring:SearchJobs"]" data-monitoring-filter />
-            </div>
-        </div>
-        <div class="table-responsive">
-            <table class="table table-hover align-middle mb-0" id="job-status-table">
-                <thead class="table-light">
-                    <tr>
-                        <th scope="col">@L["Monitoring:JobCode"]</th>
-                        <th scope="col">@L["Monitoring:JobTitle"]</th>
-                        <th scope="col">@L["Monitoring:JobGroupColumn"]</th>
-                        <th scope="col">@L["Monitoring:JobRastehColumn"]</th>
-
-
-                        <th scope="col">@L["Monitoring:JobGroupColumn"]</th>
-                        <th scope="col">@L["Monitoring:JobRastehColumn"]</th>
-
-                        <th scope="col">@L["Monitoring:JobGroupColumn"]</th>
-                        <th scope="col">@L["Monitoring:JobRastehColumn"]</th>
-                        <th scope="col">@L["Monitoring:JobGroup"]</th>
-                        <th scope="col">@L["Monitoring:JobRasteh"]</th>
-
-                        <th scope="col">@L["Monitoring:IsActive"]</th>
-                        <th scope="col">@L["Monitoring:EffectiveFrom"]</th>
-                        <th scope="col">@L["Monitoring:EffectiveTo"]</th>
-                        <th scope="col">@L["Monitoring:LastActivity"]</th>
-                        <th scope="col">@L["Monitoring:State"]</th>
-                        <th scope="col">@L["Monitoring:LastAction"]</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @if (!Model.MonitoringJobs.Any())
-
-
-                    @if (!Model.MonitoringJobs.Any())
-
-                    @if (!Model.Jobs.Any())
-
-                    {
-                        <tr>
-                            <td colspan="10" class="text-center text-muted py-4">@L["Monitoring:NoJobs"]</td>
-                        </tr>
-                    }
-                    else
-                    {
-                        foreach (var job in Model.MonitoringJobs)
-
-
-                        foreach (var job in Model.MonitoringJobs)
-
-                        foreach (var job in Model.Jobs)
-
-                        {
-                            var searchText = string.Join(" ", new[]
-                            {
-                                job.Code.ToString(),
-                                job.Title ?? string.Empty,
-                                job.JobGroupTitle ?? string.Empty,
-                                job.JobRastehTitle ?? string.Empty,
-                                job.StateTitle ?? string.Empty,
-                                job.LastActionTitle ?? string.Empty
-                            }).ToLowerInvariant();
-                            <tr data-search-text="@searchText">
-                                <td class="fw-semibold">@job.Code</td>
-                                <td>
-                                    <div class="fw-semibold">@job.Title</div>
-                                    <div class="text-muted small">@job.StateTitle</div>
-                                </td>
-                                <td>@job.JobGroupTitle</td>
-                                <td>@job.JobRastehTitle</td>
-                                <td>
-                                    @if (job.JobIsActive)
-                                    {
-                                        <span class="badge bg-success-subtle text-success">@L["Monitoring:Active"]</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="badge bg-secondary-subtle text-secondary">@L["Monitoring:Inactive"]</span>
-                                    }
-                                </td>
-                                <td>@job.EffectiveFrom?.ToString("yyyy-MM-dd")</td>
-                                <td>@job.EffectiveTo?.ToString("yyyy-MM-dd")</td>
-                                <td>@job.LastActivityTime.ToLocalTime().ToString("g")</td>
-                                <td>@job.StateTitle</td>
-                                <td>@job.LastActionTitle</td>
-                            </tr>
-                        }
-                    }
-                </tbody>
-            </table>
+            <div class="text-muted">@lastUpdatedText</div>
         </div>
     </div>
-</div>
 
-@section scripts {
-    <script>
-        (function () {
-            const filterInput = document.querySelector('[data-monitoring-filter]');
-            if (!filterInput) {
-                return;
+    @if (!Model.Services.Any())
+    {
+        <div class="card shadow-sm">
+            <div class="card-body text-center py-5">
+                <h5 class="fw-semibold mb-3">@L["Monitoring:NoServicesTitle"]</h5>
+                <p class="text-muted mb-4">@L["Monitoring:NoServicesDescription"]</p>
+                <a class="btn btn-primary" href='@Url.Content("~/Monitoring/Services/Create")'>
+                    @L["Monitoring:CreateService"]
+                </a>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="row g-3">
+            @foreach (var service in Model.Services)
+            {
+                <div class="col-12 col-md-6 col-xl-4">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-body d-flex flex-column gap-2">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <h5 class="mb-0">@service.Name</h5>
+                                @if (service.IsActive)
+                                {
+                                    <span class="badge bg-success-subtle text-success">@L["Monitoring:ServiceActive"]</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary-subtle text-secondary">@L["Monitoring:ServiceInactive"]</span>
+                                }
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(service.Description))
+                            {
+                                <p class="text-muted mb-0">@service.Description</p>
+                            }
+                            <div class="text-muted small mt-auto">
+                                @if (service.LastCheckTime.HasValue)
+                                {
+                                    @L["Monitoring:ServiceLastCheck", service.LastCheckTime.Value.ToLocalTime().ToString("g")]
+                                }
+                                else
+                                {
+                                    @L["Monitoring:ServiceNeverChecked"]
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </div>
             }
-
-            const rows = Array.from(document.querySelectorAll('#job-status-table tbody tr[data-search-text]'));
-            filterInput.addEventListener('input', function (event) {
-                const term = (event.target.value || '').toString().trim().toLowerCase();
-                rows.forEach(row => {
-                    const text = row.getAttribute('data-search-text');
-                    const visible = !term || (text && text.indexOf(term) > -1);
-                    row.style.display = visible ? '' : 'none';
-                });
-            });
-        })();
-    </script>
-}
+        </div>
+    }
+</div>

--- a/src/HRSDataIntegration.Web/Pages/Monitoring/Index.cshtml.cs
+++ b/src/HRSDataIntegration.Web/Pages/Monitoring/Index.cshtml.cs
@@ -8,22 +8,11 @@ public class IndexModel : HRSDataIntegrationPageModel
 {
     private readonly IMonitoringAppService _monitoringAppService;
 
-
-    public MonitoringDashboardDto MonitoringDashboard { get; private set; } = new();
-
-    public MonitoringSummaryDto MonitoringSummary => MonitoringDashboard?.Summary ?? new MonitoringSummaryDto();
-
-    public IReadOnlyList<JobStatusDto> MonitoringJobs => MonitoringDashboard?.Jobs ?? new List<JobStatusDto>();
-
-
     public MonitoringDashboardDto Dashboard { get; private set; } = new();
-
-    public MonitoringDashboardDto Dashboard { get; private set; }
 
     public MonitoringSummaryDto Summary => Dashboard?.Summary ?? new MonitoringSummaryDto();
 
-    public IReadOnlyList<JobStatusDto> Jobs => Dashboard?.Jobs ?? new List<JobStatusDto>();
-
+    public IReadOnlyList<MonitoringServiceDto> Services => Dashboard?.Services ?? new List<MonitoringServiceDto>();
 
     public IndexModel(IMonitoringAppService monitoringAppService)
     {
@@ -32,14 +21,6 @@ public class IndexModel : HRSDataIntegrationPageModel
 
     public async Task OnGetAsync()
     {
-        MonitoringDashboard = await _monitoringAppService.GetDashboardAsync() ?? new MonitoringDashboardDto();
-
-
-        MonitoringDashboard = await _monitoringAppService.GetDashboardAsync() ?? new MonitoringDashboardDto();
-
         Dashboard = await _monitoringAppService.GetDashboardAsync() ?? new MonitoringDashboardDto();
-
-        Dashboard = await _monitoringAppService.GetDashboardAsync();
-
     }
 }


### PR DESCRIPTION
## Summary
- replace job-based monitoring dashboard logic with service-centric defaults
- update monitoring DTOs and localization resources for user-defined services
- refresh monitoring page model and Razor UI for empty-state guidance

## Testing
- `dotnet build HRSDataIntegration.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71815a2083249781a3031c04f35b