### PR TITLE
Enable monitoring service creation permission by default

### DIFF
--- a/src/HRSDataIntegration.Application.Contracts/Permissions/HRSDataIntegrationPermissionDefinitionProvider.cs
+++ b/src/HRSDataIntegration.Application.Contracts/Permissions/HRSDataIntegrationPermissionDefinitionProvider.cs
@@ -17,11 +17,13 @@ public class HRSDataIntegrationPermissionDefinitionProvider : PermissionDefiniti
 
         var services = monitoring.AddChild(
             HRSDataIntegrationPermissions.Monitoring.Services.Default,
-            L("Permission:MonitoringServices"));
+            L("Permission:MonitoringServices"),
+            isEnabledByDefault: true);
 
         services.AddChild(
             HRSDataIntegrationPermissions.Monitoring.Services.Create,
-            L("Permission:MonitoringServicesCreate"));
+            L("Permission:MonitoringServicesCreate"),
+            isEnabledByDefault: true);
     }
 
     private static LocalizableString L(string name)


### PR DESCRIPTION
## Summary
- enable the Monitoring.Services permission node by default
- enable the Monitoring.Services.Create permission by default so default roles can access the feature

## Testing
- command was not run (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca8b4b20708324af05f96881b910b7