### PR TITLE
Add Monitoring module with permissions and menu

### DIFF
--- a/HRSDataIntegration.sln
+++ b/HRSDataIntegration.sln
@@ -37,6 +37,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HRSDataIntegration.HttpApi.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HRSDataIntegration.DbMigrator", "src\HRSDataIntegration.DbMigrator\HRSDataIntegration.DbMigrator.csproj", "{70680696-BB1E-4383-BCB2-42C3767171FB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Domain.Shared", "modules\Monitoring\src\Monitoring.Domain.Shared\Monitoring.Domain.Shared.csproj", "{B844F35B-EC79-47CA-8DFA-F241B9B97340}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Domain", "modules\Monitoring\src\Monitoring.Domain\Monitoring.Domain.csproj", "{DEF739EF-9730-4AA0-9160-D55AC69AFEC2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monitoring.Web", "modules\Monitoring\src\Monitoring.Web\Monitoring.Web.csproj", "{D14BEDAA-917A-463A-A9BE-98071035D80A}"
+EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,7 +110,19 @@ Global
 		{70680696-BB1E-4383-BCB2-42C3767171FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70680696-BB1E-4383-BCB2-42C3767171FB}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B844F35B-EC79-47CA-8DFA-F241B9B97340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B844F35B-EC79-47CA-8DFA-F241B9B97340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B844F35B-EC79-47CA-8DFA-F241B9B97340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B844F35B-EC79-47CA-8DFA-F241B9B97340}.Release|Any CPU.Build.0 = Release|Any CPU
+                {DEF739EF-9730-4AA0-9160-D55AC69AFEC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DEF739EF-9730-4AA0-9160-D55AC69AFEC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DEF739EF-9730-4AA0-9160-D55AC69AFEC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DEF739EF-9730-4AA0-9160-D55AC69AFEC2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D14BEDAA-917A-463A-A9BE-98071035D80A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D14BEDAA-917A-463A-A9BE-98071035D80A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D14BEDAA-917A-463A-A9BE-98071035D80A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D14BEDAA-917A-463A-A9BE-98071035D80A}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/Monitoring/en.json
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/Monitoring/en.json
@@ -1,0 +1,13 @@
+{
+  "culture": "en",
+  "texts": {
+    "Permission:Monitoring": "Monitoring",
+    "Permission:Monitoring.Default": "Access monitoring",
+    "Permission:Monitoring.View": "View monitoring dashboards",
+    "Permission:Monitoring.Create": "Create monitoring entries",
+    "Permission:Monitoring.Edit": "Edit monitoring entries",
+    "Permission:Monitoring.Delete": "Delete monitoring entries",
+    "Permission:Monitoring.RunCheck": "Run monitoring checks",
+    "Menu:Monitoring": "Monitoring"
+  }
+}

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/Monitoring/fa.json
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/Monitoring/fa.json
@@ -1,0 +1,13 @@
+{
+  "culture": "fa",
+  "texts": {
+    "Permission:Monitoring": "پایش",
+    "Permission:Monitoring.Default": "دسترسی به پایش",
+    "Permission:Monitoring.View": "مشاهده پایش",
+    "Permission:Monitoring.Create": "ایجاد مورد پایش",
+    "Permission:Monitoring.Edit": "ویرایش مورد پایش",
+    "Permission:Monitoring.Delete": "حذف مورد پایش",
+    "Permission:Monitoring.RunCheck": "اجرای بررسی پایش",
+    "Menu:Monitoring": "پایش"
+  }
+}

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/MonitoringResource.cs
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Localization/MonitoringResource.cs
@@ -1,0 +1,8 @@
+using Volo.Abp.Localization;
+
+namespace Monitoring.Localization;
+
+[LocalizationResourceName("Monitoring")]
+public class MonitoringResource
+{
+}

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Monitoring.Domain.Shared.csproj
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Monitoring.Domain.Shared.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../../../common.props" />
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.Ddd.Domain.Shared" Version="8.3.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Localization/Monitoring/*.json" />
+    <Content Remove="Localization/Monitoring/*.json" />
+  </ItemGroup>
+</Project>

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/MonitoringDomainSharedModule.cs
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/MonitoringDomainSharedModule.cs
@@ -1,0 +1,37 @@
+using Monitoring.Localization;
+using Monitoring.Permissions;
+using Volo.Abp.Authorization;
+using Volo.Abp.Domain.Shared;
+using Volo.Abp.Localization;
+using Volo.Abp.Modularity;
+using Volo.Abp.VirtualFileSystem;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(AbpDddDomainSharedModule)
+)]
+public class MonitoringDomainSharedModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpVirtualFileSystemOptions>(options =>
+        {
+            options.FileSets.AddEmbedded<MonitoringDomainSharedModule>();
+        });
+
+        Configure<AbpLocalizationOptions>(options =>
+        {
+            options.Resources
+                .Add<MonitoringResource>("en")
+                .AddVirtualJson("/Localization/Monitoring");
+
+            options.DefaultResourceType = typeof(MonitoringResource);
+        });
+
+        Configure<AbpAuthorizationOptions>(options =>
+        {
+            options.Providers.Add<MonitoringPermissionDefinitionProvider>();
+        });
+    }
+}

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Permissions/MonitoringPermissionDefinitionProvider.cs
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Permissions/MonitoringPermissionDefinitionProvider.cs
@@ -1,0 +1,25 @@
+using Monitoring.Localization;
+using Volo.Abp.Authorization.Permissions;
+using Volo.Abp.Localization;
+
+namespace Monitoring.Permissions;
+
+public class MonitoringPermissionDefinitionProvider : PermissionDefinitionProvider
+{
+    public override void Define(IPermissionDefinitionContext context)
+    {
+        var monitoringGroup = context.AddGroup(MonitoringPermissions.GroupName, L("Permission:Monitoring"));
+
+        var monitoringPermission = monitoringGroup.AddPermission(MonitoringPermissions.Default, L("Permission:Monitoring.Default"));
+        monitoringPermission.AddChild(MonitoringPermissions.View, L("Permission:Monitoring.View"));
+        monitoringPermission.AddChild(MonitoringPermissions.Create, L("Permission:Monitoring.Create"));
+        monitoringPermission.AddChild(MonitoringPermissions.Edit, L("Permission:Monitoring.Edit"));
+        monitoringPermission.AddChild(MonitoringPermissions.Delete, L("Permission:Monitoring.Delete"));
+        monitoringPermission.AddChild(MonitoringPermissions.RunCheck, L("Permission:Monitoring.RunCheck"));
+    }
+
+    private static LocalizableString L(string name)
+    {
+        return LocalizableString.Create<MonitoringResource>(name);
+    }
+}

--- a/modules/Monitoring/src/Monitoring.Domain.Shared/Permissions/MonitoringPermissions.cs
+++ b/modules/Monitoring/src/Monitoring.Domain.Shared/Permissions/MonitoringPermissions.cs
@@ -1,0 +1,13 @@
+namespace Monitoring.Permissions;
+
+public static class MonitoringPermissions
+{
+    public const string GroupName = "Monitoring";
+
+    public const string Default = GroupName + ".Default";
+    public const string View = GroupName + ".View";
+    public const string Create = GroupName + ".Create";
+    public const string Edit = GroupName + ".Edit";
+    public const string Delete = GroupName + ".Delete";
+    public const string RunCheck = GroupName + ".RunCheck";
+}

--- a/modules/Monitoring/src/Monitoring.Domain/Monitoring.Domain.csproj
+++ b/modules/Monitoring/src/Monitoring.Domain/Monitoring.Domain.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../../../common.props" />
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.Ddd.Domain" Version="8.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Monitoring.Domain.Shared/Monitoring.Domain.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/modules/Monitoring/src/Monitoring.Domain/MonitoringDomainModule.cs
+++ b/modules/Monitoring/src/Monitoring.Domain/MonitoringDomainModule.cs
@@ -1,0 +1,12 @@
+using Volo.Abp.Domain;
+using Volo.Abp.Modularity;
+
+namespace Monitoring;
+
+[DependsOn(
+    typeof(AbpDddDomainModule),
+    typeof(MonitoringDomainSharedModule)
+)]
+public class MonitoringDomainModule : AbpModule
+{
+}

--- a/modules/Monitoring/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
+++ b/modules/Monitoring/src/Monitoring.Web/Menus/MonitoringMenuContributor.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Monitoring.Localization;
+using Monitoring.Permissions;
+using Volo.Abp.UI.Navigation;
+
+namespace Monitoring.Menus;
+
+public class MonitoringMenuContributor : IMenuContributor
+{
+    public async Task ConfigureMenuAsync(MenuConfigurationContext context)
+    {
+        if (context.Menu.Name != StandardMenus.Main)
+        {
+            return;
+        }
+
+        var l = context.GetLocalizer<MonitoringResource>();
+
+        var monitoringMenu = new ApplicationMenuItem(
+            name: "Monitoring",
+            displayName: l["Menu:Monitoring"],
+            url: "/Monitoring",
+            icon: "fa fa-heartbeat",
+            order: 1000,
+            requiredPermissionName: MonitoringPermissions.Default
+        );
+
+        if (await context.IsGrantedAsync(MonitoringPermissions.Default))
+        {
+            context.Menu.AddItem(monitoringMenu);
+        }
+    }
+}

--- a/modules/Monitoring/src/Monitoring.Web/Monitoring.Web.csproj
+++ b/modules/Monitoring/src/Monitoring.Web/Monitoring.Web.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <Import Project="../../../../common.props" />
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Monitoring.Web</RootNamespace>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.AspNetCore.Mvc" Version="8.3.1" />
+    <PackageReference Include="Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared" Version="8.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Monitoring.Domain.Shared/Monitoring.Domain.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Localization/Monitoring/*.json" />
+    <Content Remove="Localization/Monitoring/*.json" />
+  </ItemGroup>
+</Project>

--- a/modules/Monitoring/src/Monitoring.Web/MonitoringWebModule.cs
+++ b/modules/Monitoring/src/Monitoring.Web/MonitoringWebModule.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
+using Monitoring.Menus;
+using Monitoring.Permissions;
+using Volo.Abp.AspNetCore.Mvc;
+using Volo.Abp.Modularity;
+using Volo.Abp.UI.Navigation;
+using Volo.Abp.VirtualFileSystem;
+
+namespace Monitoring.Web;
+
+[DependsOn(
+    typeof(AbpAspNetCoreMvcModule),
+    typeof(MonitoringDomainSharedModule)
+)]
+public class MonitoringWebModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpNavigationOptions>(options =>
+        {
+            options.MenuContributors.Add(new MonitoringMenuContributor());
+        });
+
+        Configure<RazorPagesOptions>(options =>
+        {
+            options.Conventions.AuthorizePage("/Monitoring/Index", MonitoringPermissions.Default);
+        });
+
+        Configure<AbpVirtualFileSystemOptions>(options =>
+        {
+            options.FileSets.AddEmbedded<MonitoringWebModule>();
+        });
+
+        context.Services.AddMvc().AddApplicationPart(typeof(MonitoringWebModule).Assembly);
+    }
+}

--- a/modules/Monitoring/src/Monitoring.Web/Pages/Monitoring/Index.cshtml
+++ b/modules/Monitoring/src/Monitoring.Web/Pages/Monitoring/Index.cshtml
@@ -1,0 +1,6 @@
+@page "/Monitoring"
+@using Monitoring.Permissions
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(MonitoringPermissions.Default)]
+
+<h1>Monitoring</h1>


### PR DESCRIPTION
## Summary
- add Monitoring domain shared, domain, and web projects with consistent ABP 8.3.1 dependencies
- define monitoring permissions, localization resources, and register the permission provider
- add a monitoring menu contributor, Razor page, and solution references for the new module

## Testing
- `dotnet build HRSDataIntegration.sln` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca958b1b6883248cd64f72cdfdf017